### PR TITLE
Fixed issue where counterclockwise move win gets detected

### DIFF
--- a/marblemind_app/lib/screens/game_board.dart
+++ b/marblemind_app/lib/screens/game_board.dart
@@ -62,7 +62,18 @@ class GameBoardState extends State<GameBoard> {
     if (_grid[row][col].marble != null) {
       // If the tapped cell contains the current player's marble, allow counterclockwise movement
       if (_grid[row][col].marble == currentPlayer) {
-        GameLogic.moveMarbleCounterclockwise(_grid, row, col);  // Move marble counterclockwise
+        // Perform counterclockwise movement and check for win
+        bool winDetected = GameLogic.moveMarbleCounterclockwise(_grid, row, col); 
+        
+        // Ensure UI is updated after the move
+        setState(() {});
+      
+      if (winDetected) {
+          gameOver = true;
+          stopTurnTimer(this);
+          _showWinnerDialog();
+          return;
+        }
       } else {
         // If the tapped cell contains the opponent's marble, do nothing
         return;

--- a/marblemind_app/lib/utils/game_logic.dart
+++ b/marblemind_app/lib/utils/game_logic.dart
@@ -2,9 +2,10 @@ import '../models/cell.dart';
 
 class GameLogic {
   // Function to move the marble in a counterclockwise direction
-  static void moveMarbleCounterclockwise(
+  static bool moveMarbleCounterclockwise(
       List<List<Cell>> grid, int row, int col) {
     int directionIndex = 0; // Initial direction is up
+    bool marbleMoved = false;
 
     // Directions for counterclockwise movement: up, left, down, right
     List<List<int>> directions = [
@@ -24,13 +25,22 @@ class GameLogic {
         if (grid[newRow][newCol].marble == null) {
           grid[newRow][newCol].marble = grid[row][col].marble;
           grid[row][col].marble = null; // Empty the old position
-          break; // Exit the loop once the marble is moved
+          marbleMoved = true; // Indicate that a move occurred
+           break; // Exit the loop once the marble is moved
         }
       }
 
       // Update the direction to the next one in counterclockwise order
       directionIndex = (directionIndex + 1) % 4;
     }
+
+    // Check for a winner after the marble is successfully moved
+    if (marbleMoved && checkForWinner(grid)) {
+      return true; // Winning condition met
+  }
+
+    // If no winner found, return false
+    return false;
   }
 
   // Function to check if there is a winner


### PR DESCRIPTION
When marble moved counterclockwise and winning condition was achieved, win dialogbox appears and counterclockwise move doesn't execute. Fixed the issue, after which first move happens then win condition is checked and declared